### PR TITLE
ENH: reduce X axes PLC limits for MR1/2K3

### DIFF
--- a/iocBoot/ioc-txi-optics/Makefile
+++ b/iocBoot/ioc-txi-optics/Makefile
@@ -9,6 +9,6 @@ PROJECT_PATH := ../../lcls-plc-txi-optics/lcls-plc-txi-optics.tsproj
 PLC := txi_optics
 
 PYTMC_OPTS := 
-PREFIX := PLC:TXI:OPTICS
+PREFIX := PLC:TXI:KFE:OPTICS
 
 include $(IOC_TOP)/iocBoot/templates/Makefile.base

--- a/lcls-plc-txi-optics/_Config/NC/Axes/M1K3-Xdwn.xti
+++ b/lcls-plc-txi-optics/_Config/NC/Axes/M1K3-Xdwn.xti
@@ -1325,8 +1325,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="1" ScaleFactorDenominator="1000" MaxCount="#xffffffff">
-				<SoftEndMinControl Enable="true" Range="17400"/>
-				<SoftEndMaxControl Enable="true" Range="24500"/>
+				<SoftEndMinControl Enable="true" Range="21276"/>
+				<SoftEndMaxControl Enable="true" Range="22876"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/lcls-plc-txi-optics/_Config/NC/Axes/M1K3-Xup.xti
+++ b/lcls-plc-txi-optics/_Config/NC/Axes/M1K3-Xup.xti
@@ -1325,8 +1325,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="1" ScaleFactorDenominator="1000" MaxCount="#xffffffff">
-				<SoftEndMinControl Enable="true" Range="16300"/>
-				<SoftEndMaxControl Enable="true" Range="23200"/>
+				<SoftEndMinControl Enable="true" Range="20176"/>
+				<SoftEndMaxControl Enable="true" Range="21576"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/lcls-plc-txi-optics/_Config/NC/Axes/M2K3-Xdwn.xti
+++ b/lcls-plc-txi-optics/_Config/NC/Axes/M2K3-Xdwn.xti
@@ -1326,8 +1326,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="1" ScaleFactorDenominator="1000" MaxCount="#xffffffff">
-				<SoftEndMinControl Enable="true" Range="15730"/>
-				<SoftEndMaxControl Enable="true" Range="22780"/>
+				<SoftEndMinControl Enable="true" Range="18074"/>
+				<SoftEndMaxControl Enable="true" Range="19674"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/lcls-plc-txi-optics/_Config/NC/Axes/M2K3-Xup.xti
+++ b/lcls-plc-txi-optics/_Config/NC/Axes/M2K3-Xup.xti
@@ -1326,8 +1326,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="1" ScaleFactorDenominator="1000" MaxCount="#xffffffff">
-				<SoftEndMinControl Enable="true" Range="16950"/>
-				<SoftEndMaxControl Enable="true" Range="23800"/>
+				<SoftEndMinControl Enable="true" Range="19294"/>
+				<SoftEndMaxControl Enable="true" Range="20694"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/lcls-plc-txi-optics/_Config/NC/Axes/M2K3-Xup.xti
+++ b/lcls-plc-txi-optics/_Config/NC/Axes/M2K3-Xup.xti
@@ -1318,7 +1318,7 @@ External Setpoint Generation:
 	<Axis Id="8" CreateSymbols="true" AxisType="1" AxisFolder="M2K3">
 		<Name>__FILENAME__</Name>
 		<AxisPara>
-			<General UnitName=""/>
+			<General UnitName="um"/>
 			<Dynamic AccelerationMaximum="1000" DecelerationMaximum="1000" Acceleration="1000" Deceleration="1000" Jerk="5000" DelayTime="0.008"/>
 			<Velo Maximum="150"/>
 			<TargetPosControl Range="0.05" Time="0.01"/>

--- a/lcls-plc-txi-optics/_Config/NC/Axes/M2K3-Yup.xti
+++ b/lcls-plc-txi-optics/_Config/NC/Axes/M2K3-Yup.xti
@@ -1318,7 +1318,7 @@ External Setpoint Generation:
 	<Axis Id="6" CreateSymbols="true" AxisType="1" AxisFolder="M2K3">
 		<Name>__FILENAME__</Name>
 		<AxisPara>
-			<General UnitName=""/>
+			<General UnitName="um"/>
 			<Dynamic Acceleration="5050" Deceleration="5050" Jerk="5100500" DelayTime="0.008"/>
 			<Velo Maximum="100"/>
 			<TargetPosControl Range="0.05" Time="0.01"/>

--- a/lcls-plc-txi-optics/_Config/PLC/txi_optics.xti
+++ b/lcls-plc-txi-optics/_Config/PLC/txi_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{6F8D8EEF-45CD-488B-9616-A25D9A723693}" Name="txi_optics" PrjFilePath="..\..\txi_optics\txi_optics.plcproj" TmcFilePath="..\..\txi_optics\txi_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="txi_optics\txi_optics.tmc" TmcHash="{F6C724FE-CAB1-F420-0E8F-16AE6323627A}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="txi_optics\txi_optics.tmc" TmcHash="{ED650691-0B2F-F557-E678-94395C90B2EF}">
 			<Name>txi_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -2227,6 +2227,7 @@ External Setpoint Generation:
 				<Link VarA="PlcTask Inputs^MAIN.M1K3.fbRunHOMS.stXdwnEnc^Count" VarB="FB Inputs Channel 2^Position" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^MAIN.M1K3.fbRunHOMS.stXupEnc^Count" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^MAIN.M3.nRawEncoderULINT" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^MAIN.M4.nRawEncoderULINT" VarB="FB Inputs Channel 2^Position" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 6 (EK1122)^EK1100_M1K3^EL5042_M1K3_Yupdwn">
 				<Link VarA="PlcTask Inputs^MAIN.M1.nRawEncoderULINT" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
@@ -2323,6 +2324,7 @@ External Setpoint Generation:
 				<Link VarA="PlcTask Inputs^MAIN.M2K3.fbRunHOMS.stXdwnEnc^Count" VarB="FB Inputs Channel 2^Position" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^MAIN.M2K3.fbRunHOMS.stXupEnc^Count" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^MAIN.M8.nRawEncoderULINT" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^MAIN.M9.nRawEncoderULINT" VarB="FB Inputs Channel 2^Position" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 6 (EK1122)^EK1100_M2K3^EL5042_M2K3_Yupdwn">
 				<Link VarA="PlcTask Inputs^MAIN.M2K3.fbRunHOMS.stYdwnEnc^Count" VarB="FB Inputs Channel 2^Position" AutoLink="true"/>

--- a/lcls-plc-txi-optics/txi_optics/POUs/MAIN.TcPOU
+++ b/lcls-plc-txi-optics/txi_optics/POUs/MAIN.TcPOU
@@ -32,7 +32,8 @@ VAR
     fbMotionStage_m3 : FB_MotionStage;
 
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K3_Xdwn]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K3_Xdwn]^STM Status^Status^Digital input 2'}
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K3_Xdwn]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K3_Xupdwn]^FB Inputs Channel 2^Position'}
     {attribute 'pytmc' := '
         pv: MR1K3:SOMS:MMS:XDWN
     '}
@@ -124,7 +125,8 @@ VAR
     fbMotionStage_m8 : FB_MotionStage;
 
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M2K3_Xdwn]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M2K3_Xdwn]^STM Status^Status^Digital input 2'}
+                              .bLimitBackwardEnable:=TIIB[EL7047_M2K3_Xdwn]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M2K3_Xupdwn]^FB Inputs Channel 2^Position'}
     {attribute 'pytmc' := '
         pv: MR2K3:SOMS:MMS:XDWN
     '}

--- a/lcls-plc-txi-optics/txi_optics/txi_optics.tmc
+++ b/lcls-plc-txi-optics/txi_optics/txi_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{F6C724FE-CAB1-F420-0E8F-16AE6323627A}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{ED650691-0B2F-F557-E678-94395C90B2EF}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -69448,7 +69448,8 @@ ELSE:
               <Property>
                 <Name>TcLinkTo</Name>
                 <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K3_Xdwn]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K3_Xdwn]^STM Status^Status^Digital input 2</Value>
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K3_Xdwn]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K3_Xupdwn]^FB Inputs Channel 2^Position</Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -69750,7 +69751,8 @@ ELSE:
               <Property>
                 <Name>TcLinkTo</Name>
                 <Value>.bLimitForwardEnable:=TIIB[EL7047_M2K3_Xdwn]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M2K3_Xdwn]^STM Status^Status^Digital input 2</Value>
+                              .bLimitBackwardEnable:=TIIB[EL7047_M2K3_Xdwn]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M2K3_Xupdwn]^FB Inputs Channel 2^Position</Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -71068,7 +71070,7 @@ ELSE:
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-06-27T16:09:58</Value>
+          <Value>2024-10-04T15:12:55</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Update MR1/2K3 PLC limits to reflect change in X axes hardstop position change.
- Link encoder counts via pragmas for down stream X motors.
- MR2K3 set units for Y and X to um
- Change IOC PREFIX := PLC:TXI:KFE:OPTICS
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Mechanical engineering setting hard stops.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Online changes pushed and documented from online values.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-6332
## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
